### PR TITLE
Avoid Triggering Reconciliation for Owned Resources

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -5,7 +5,7 @@ Bootstrapped using [Kubebuilder](https://book.kubebuilder.io/introduction.html)
 
 Start OpenFGA
 ```
-cd hosting/docker-comopse
+cd ../development/docker-comopse
 docker-compose up
 ```
 

--- a/operator/internal/controller/authorizationmodelrequest_controller_test.go
+++ b/operator/internal/controller/authorizationmodelrequest_controller_test.go
@@ -149,6 +149,10 @@ var _ = Describe("AuthorizationModelRequest Controller", func() {
 				store := &extensionsv1.Store{}
 				return k8sClient.Get(ctx, typeNamespacedName, store)
 			}, duration, interval).Should(Succeed())
+			Eventually(func() error {
+				authModel := &extensionsv1.AuthorizationModel{}
+				return k8sClient.Get(ctx, typeNamespacedName, authModel)
+			}, duration, interval).Should(Succeed())
 		})
 
 		It("given existing store when create store resource then return existing", func() {


### PR DESCRIPTION
Reconciliation was triggered not only for AuthorizationModelRequest but also for AuthorizationModel and Store CRD changes.

An AuthorizationModelRequest created both a Store and AuthorizationModel, causing additional reconciliations. A concurrency issue occurred where Kubernetes incorrectly reported the AuthorizationModel as non-existent, leading to a duplicate in OpenFGA but failing when creating the AuthorizationModel CRD in Kubernetes.

To fix this, reconciliation triggers for AuthorizationModel and Store changes were removed.

Also a predicate was added to prevent reconciliation when an AuthorizationModelRequest is deleted.

References
- https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler