### PR TITLE
Migration frm

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ spec:
 
 If you have existing stores and authorization models and wish to migrate to use the operator without deploying a new authorization model or store, you can retain the existing ones. Creating new models would require reconciling all existing relationship tuples, which might not be desirable.
 
-To address this, the `AuthorizationModelRequest` resource provides the properties existingStoreId and existingAuthorizationModelId, allowing you to reuse your current setup.
+To address this, the `AuthorizationModelRequest` resource provides the properties `existingStoreId` and `existingAuthorizationModelId`, allowing you to reuse your current setup.
 
 Example configuration:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -373,6 +373,41 @@ spec:
         name: main
 ```
 
+## Migration Guide for Using Operator with Existing Models
+
+If you have existing stores and authorization models and wish to migrate to use the operator without deploying a new authorization model or store, you can retain the existing ones. Creating new models would require reconciling all existing relationship tuples, which might not be desirable.
+
+To address this, the `AuthorizationModelRequest` resource provides the properties existingStoreId and existingAuthorizationModelId, allowing you to reuse your current setup.
+
+Example configuration:
+```yaml
+apiVersion: extensions.fga-operator/v1
+kind: AuthorizationModelRequest
+metadata:
+  name: documents
+spec:
+  existingStoreId: 01J1N8HCY7MQP4QP3GVDWTM9ZG
+  instances:
+    - version:
+        major: 1
+        minor: 1
+        patch: 1
+      existingAuthorizationModelId: 01J23CJTA8X4K87X62ECX1Y58Z
+      authorizationModel: |
+        model
+          schema 1.1
+          
+        type user
+          
+        type document
+          relations
+            define reader: [user]
+            define writer: [user]
+            define owner: [user]
+```
+
+In this configuration, the operator will **not** create a store and authorization model in OpenFGA. It will only handle the creation of Custom Resource Definitions (CRDs), such as `AuthorizationModel` and `Store`, and perform the necessary deployment updates.
+
 ## Installation using Helm
 
 To install the Helm chart for fga-operator, follow the steps below:

--- a/charts/fga-operator/crds/authorizationmodelrequest-crd.yaml
+++ b/charts/fga-operator/crds/authorizationmodelrequest-crd.yaml
@@ -47,10 +47,20 @@ spec:
             description: AuthorizationModelRequestSpec defines the desired state of
               AuthorizationModelRequest
             properties:
+              existingStoreId:
+                description: |-
+                  ExistingStoreId specifies the ID of an existing store in the system.
+                  Only applicable when migrating from existing infrastructure where the operator was not previously used.
+                type: string
               instances:
                 items:
                   properties:
                     authorizationModel:
+                      type: string
+                    existingAuthorizationModelId:
+                      description: |-
+                        ExistingAuthorizationModelId specifies the ID of an existing authorization model in the system.
+                        Only applicable when migrating from existing infrastructure where the operator was not previously used.
                       type: string
                     version:
                       properties:

--- a/development/docker-compose/docker-compose.yaml
+++ b/development/docker-compose/docker-compose.yaml
@@ -1,12 +1,12 @@
 networks:
-  openfga:
+  openfga-fga-operator:
 
 services:
-  postgres:
+  postgres-fga-operator:
     image: postgres:14
-    container_name: postgres
+    container_name: postgres-fga-operator
     networks:
-      - openfga
+      - openfga-fga-operator
     ports:
       - "5432:5432"
     environment:
@@ -18,38 +18,34 @@ services:
       timeout: 5s
       retries: 5
 
-  migrate:
+  migrate-fga-operator:
     depends_on:
-      postgres:
+      postgres-fga-operator:
         condition: service_healthy
     image: openfga/openfga:v1.5
-    container_name: migrate
+    container_name: migrate-fga-operator
     command: migrate
     environment:
       - OPENFGA_DATASTORE_ENGINE=postgres
-      - OPENFGA_DATASTORE_URI=postgres://postgres:password@postgres:5432/postgres
+      - OPENFGA_DATASTORE_URI=postgres://postgres:password@postgres-fga-operator:5432/postgres
     networks:
-      - openfga
+      - openfga-fga-operator
 
-  openfga:
+  openfga-fga-operator:
     depends_on:
-      migrate:
+      migrate-fga-operator:
         condition: service_completed_successfully
     image: openfga/openfga:v1.5
-    container_name: openfga
+    container_name: openfga-fga-operator
     environment:
       - OPENFGA_DATASTORE_ENGINE=postgres
-      - OPENFGA_DATASTORE_URI=postgres://postgres:password@postgres:5432/postgres
+      - OPENFGA_DATASTORE_URI=postgres://postgres:password@postgres-fga-operator:5432/postgres
       - OPENFGA_LOG_FORMAT=json
       - OPENFGA_AUTHN_METHOD=preshared
       - OPENFGA_AUTHN_PRESHARED_KEYS=foobar
     command: run
     networks:
-      - openfga
+      - openfga-fga-operator
     ports:
       # Needed for the http server
       - "8089:8080"
-      # Needed for the grpc server (if used)
-      - "8081:8081"
-      # Needed for the playground (Do not enable in prod!)
-      - "3000:3000"

--- a/operator/api/v1/authorizationmodelrequest_types.go
+++ b/operator/api/v1/authorizationmodelrequest_types.go
@@ -51,7 +51,10 @@ const (
 type AuthorizationModelRequestSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
-	Instances []AuthorizationModelRequestInstance `json:"instances,omitempty"`
+	// ExistingStoreId specifies the ID of an existing store in the system.
+	// Only applicable when migrating from existing infrastructure where the operator was not previously used.
+	ExistingStoreId string                              `json:"existingStoreId,omitempty"`
+	Instances       []AuthorizationModelRequestInstance `json:"instances,omitempty"`
 }
 
 // AuthorizationModelRequestStatus defines the observed state of AuthorizationModelRequest.
@@ -138,6 +141,9 @@ func (v ModelVersion) String() string {
 }
 
 type AuthorizationModelRequestInstance struct {
-	AuthorizationModel string       `json:"authorizationModel,omitempty"`
-	Version            ModelVersion `json:"version,omitempty"`
+	// ExistingAuthorizationModelId specifies the ID of an existing authorization model in the system.
+	// Only applicable when migrating from existing infrastructure where the operator was not previously used.
+	ExistingAuthorizationModelId string       `json:"existingAuthorizationModelId,omitempty"`
+	AuthorizationModel           string       `json:"authorizationModel,omitempty"`
+	Version                      ModelVersion `json:"version,omitempty"`
 }

--- a/operator/config/crd/bases/extensions.fga-operator_authorizationmodelrequests.yaml
+++ b/operator/config/crd/bases/extensions.fga-operator_authorizationmodelrequests.yaml
@@ -48,10 +48,20 @@ spec:
             description: AuthorizationModelRequestSpec defines the desired state of
               AuthorizationModelRequest
             properties:
+              existingStoreId:
+                description: |-
+                  ExistingStoreId specifies the ID of an existing store in the system.
+                  Only applicable when migrating from existing infrastructure where the operator was not previously used.
+                type: string
               instances:
                 items:
                   properties:
                     authorizationModel:
+                      type: string
+                    existingAuthorizationModelId:
+                      description: |-
+                        ExistingAuthorizationModelId specifies the ID of an existing authorization model in the system.
+                        Only applicable when migrating from existing infrastructure where the operator was not previously used.
                       type: string
                     version:
                       properties:

--- a/operator/internal/controller/authorizationmodelrequest/authorizationmodelrequest_controller.go
+++ b/operator/internal/controller/authorizationmodelrequest/authorizationmodelrequest_controller.go
@@ -182,6 +182,7 @@ func updateAuthorizationModelWithMissingInstances(
 
 	modelInstances := authorizationModel.Spec.Instances
 	for _, modelRequestInstance := range missingInstances {
+		// TODO
 		authModelId, err := openFgaService.CreateAuthorizationModel(ctx, modelRequestInstance.AuthorizationModel, log)
 		if err != nil {
 			return false, err
@@ -295,6 +296,7 @@ func (r *AuthorizationModelRequestReconciler) createAuthorizationModel(
 
 	definitions := make([]extensionsv1.AuthorizationModelDefinition, len(authorizationModelRequest.Spec.Instances))
 	for i, instance := range authorizationModelRequest.Spec.Instances {
+		// TODO
 		authModelId, err := openFgaService.CreateAuthorizationModel(ctx, instance.AuthorizationModel, log)
 		if err != nil {
 			return nil, err

--- a/operator/internal/controller/authorizationmodelrequest/authorizationmodelrequest_controller_test.go
+++ b/operator/internal/controller/authorizationmodelrequest/authorizationmodelrequest_controller_test.go
@@ -174,7 +174,8 @@ var _ = Describe("AuthorizationModelRequest Controller", func() {
 			mockFactory := fgainternal.NewMockPermissionServiceFactory(goMockController)
 			mockService := fgainternal.NewMockPermissionService(goMockController)
 			mockFactory.EXPECT().GetService(gomock.Any()).Return(mockService, nil).Times(1)
-			mockService.EXPECT().CheckExistingStores(gomock.Any(), gomock.Any()).Times(0)
+			mockService.EXPECT().CheckExistingStoresByName(gomock.Any(), gomock.Any()).Times(0)
+			mockService.EXPECT().CheckExistingStoresById(gomock.Any(), gomock.Any()).Times(1)
 			mockService.EXPECT().CreateStore(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			mockService.EXPECT().SetStoreId(gomock.Any()).Times(1)
 			mockService.EXPECT().CreateAuthorizationModel(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
@@ -312,7 +313,8 @@ var _ = Describe("AuthorizationModelRequest Controller", func() {
 			mockFactory := fgainternal.NewMockPermissionServiceFactory(goMockController)
 			mockService := fgainternal.NewMockPermissionService(goMockController)
 			mockFactory.EXPECT().GetService(gomock.Any()).Return(mockService, nil)
-			mockService.EXPECT().CheckExistingStores(gomock.Any(), gomock.Any()).Return(nil, nil)
+			mockService.EXPECT().CheckExistingStoresByName(gomock.Any(), gomock.Any()).Return(nil, nil)
+			mockService.EXPECT().CheckExistingStoresById(gomock.Any(), gomock.Any()).Times(0)
 			mockService.EXPECT().CreateStore(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error"))
 
 			fakeRecorder := record.NewFakeRecorder(5)
@@ -355,7 +357,8 @@ var _ = Describe("AuthorizationModelRequest Controller", func() {
 			mockFactory := fgainternal.NewMockPermissionServiceFactory(goMockController)
 			mockService := fgainternal.NewMockPermissionService(goMockController)
 			mockFactory.EXPECT().GetService(gomock.Any()).Return(mockService, nil)
-			mockService.EXPECT().CheckExistingStores(gomock.Any(), gomock.Any()).Return(nil, nil)
+			mockService.EXPECT().CheckExistingStoresByName(gomock.Any(), gomock.Any()).Return(nil, nil)
+			mockService.EXPECT().CheckExistingStoresById(gomock.Any(), gomock.Any()).Times(0)
 			mockService.EXPECT().CreateStore(gomock.Any(), gomock.Any(), gomock.Any()).Return(&store, nil)
 			mockService.EXPECT().SetStoreId(gomock.Any())
 			mockService.EXPECT().
@@ -394,7 +397,8 @@ var _ = Describe("AuthorizationModelRequest Controller", func() {
 
 		It("given existing store when create store resource then return existing", func() {
 			mockService := fgainternal.NewMockPermissionService(goMockController)
-			mockService.EXPECT().CheckExistingStores(gomock.Any(), gomock.Any()).Return(&fgainternal.Store{
+			mockService.EXPECT().CheckExistingStoresById(gomock.Any(), gomock.Any()).Times(0)
+			mockService.EXPECT().CheckExistingStoresByName(gomock.Any(), gomock.Any()).Return(&fgainternal.Store{
 				Id:        "foo",
 				Name:      resourceName,
 				CreatedAt: time.Now(),
@@ -414,7 +418,8 @@ var _ = Describe("AuthorizationModelRequest Controller", func() {
 		It("given no existing store when create store resource then create new store", func() {
 			storeId := uuid.NewString()
 			mockService := fgainternal.NewMockPermissionService(goMockController)
-			mockService.EXPECT().CheckExistingStores(gomock.Any(), gomock.Any()).Return(nil, nil)
+			mockService.EXPECT().CheckExistingStoresByName(gomock.Any(), gomock.Any()).Return(nil, nil)
+			mockService.EXPECT().CheckExistingStoresById(gomock.Any(), gomock.Any()).Times(0)
 			mockService.EXPECT().CreateStore(gomock.Any(), gomock.Any(), gomock.Any()).Return(&fgainternal.Store{
 				Id:        storeId,
 				Name:      resourceName,

--- a/operator/internal/controller/authorizationmodelrequest/authorizationmodelrequest_controller_test.go
+++ b/operator/internal/controller/authorizationmodelrequest/authorizationmodelrequest_controller_test.go
@@ -148,6 +148,151 @@ var _ = Describe("AuthorizationModelRequest Controller", func() {
 			deleteResource(&extensionsv1.Store{})
 		})
 
+		It("given existing store but missing in open fga, then do not create store resource", func() {
+			// Arrange
+			existingStoreId := uuid.NewString()
+			existingAuthorizationModelId := uuid.NewString()
+			resource := extensionsv1.AuthorizationModelRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: namespaceName,
+					UID:       types.UID(uuid.NewString()),
+				},
+				Spec: extensionsv1.AuthorizationModelRequestSpec{
+					ExistingStoreId: existingStoreId,
+					Instances: []extensionsv1.AuthorizationModelRequestInstance{
+						{
+							ExistingAuthorizationModelId: existingAuthorizationModelId,
+							AuthorizationModel:           model,
+							Version:                      version,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, &resource)).To(Succeed())
+
+			mockFactory := fgainternal.NewMockPermissionServiceFactory(goMockController)
+			mockService := fgainternal.NewMockPermissionService(goMockController)
+			mockFactory.EXPECT().GetService(gomock.Any()).Return(mockService, nil).Times(1)
+
+			mockService.EXPECT().CheckExistingStoresByName(gomock.Any(), gomock.Any()).Times(0)
+			mockService.EXPECT().CheckExistingStoresById(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("store not found")).Times(1)
+			mockService.EXPECT().CreateStore(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			mockService.EXPECT().SetStoreId(gomock.Any()).Times(0)
+
+			mockService.EXPECT().CreateAuthorizationModel(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			mockService.EXPECT().CheckAuthorizationModelExists(gomock.Any(), gomock.Any()).Times(0)
+
+			fakeRecorder := record.NewFakeRecorder(5)
+			reconciler := &AuthorizationModelRequestReconciler{
+				Client:                   k8sClient,
+				Scheme:                   k8sClient.Scheme(),
+				Recorder:                 fakeRecorder,
+				Clock:                    clock.RealClock{},
+				PermissionServiceFactory: mockFactory,
+			}
+
+			// Act
+			_, err := reconciler.Reconcile(ctx, request)
+
+			// Assert
+			Expect(err).To(HaveOccurred())
+			Consistently(func() error {
+				store := &extensionsv1.Store{}
+				return k8sClient.Get(ctx, typeNamespacedName, store)
+			}, duration, interval).ShouldNot(Succeed())
+			Consistently(func() error {
+				authModel := &extensionsv1.AuthorizationModel{}
+				return k8sClient.Get(ctx, typeNamespacedName, authModel)
+			}, duration, interval).ShouldNot(Succeed())
+			Eventually(func() (extensionsv1.AuthorizationModelRequestStatusState, error) {
+				authModelRequest := &extensionsv1.AuthorizationModelRequest{}
+				if err := k8sClient.Get(ctx, typeNamespacedName, authModelRequest); err != nil {
+					return "", err
+				}
+				return authModelRequest.Status.State, nil
+			}, duration, interval).Should(Equal(extensionsv1.SynchronizationFailed))
+			validateEvent(fakeRecorder.Events, EventReasonStoreFailed)
+		})
+
+		It("given existing authorization model but missing in open fga, then do not create authorization model resource", func() {
+			// Arrange
+			existingStoreId := uuid.NewString()
+			existingAuthorizationModelId := uuid.NewString()
+			resource := extensionsv1.AuthorizationModelRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: namespaceName,
+					UID:       types.UID(uuid.NewString()),
+				},
+				Spec: extensionsv1.AuthorizationModelRequestSpec{
+					ExistingStoreId: existingStoreId,
+					Instances: []extensionsv1.AuthorizationModelRequestInstance{
+						{
+							ExistingAuthorizationModelId: existingAuthorizationModelId,
+							AuthorizationModel:           model,
+							Version:                      version,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, &resource)).To(Succeed())
+
+			mockFactory := fgainternal.NewMockPermissionServiceFactory(goMockController)
+			mockService := fgainternal.NewMockPermissionService(goMockController)
+			mockFactory.EXPECT().GetService(gomock.Any()).Return(mockService, nil).Times(1)
+
+			mockService.EXPECT().CheckExistingStoresByName(gomock.Any(), gomock.Any()).Times(0)
+			mockService.EXPECT().CheckExistingStoresById(gomock.Any(), gomock.Any()).Return(&fgainternal.Store{
+				Id:        existingStoreId,
+				Name:      resourceName,
+				CreatedAt: time.Now(),
+			}, nil).Times(1)
+			mockService.EXPECT().CreateStore(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			mockService.EXPECT().SetStoreId(gomock.Any()).Times(1)
+
+			mockService.EXPECT().CheckAuthorizationModelExists(gomock.Any(), gomock.Any()).Times(1).Return(false, nil)
+			mockService.EXPECT().CreateAuthorizationModel(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+			fakeRecorder := record.NewFakeRecorder(5)
+			reconciler := &AuthorizationModelRequestReconciler{
+				Client:                   k8sClient,
+				Scheme:                   k8sClient.Scheme(),
+				Recorder:                 fakeRecorder,
+				Clock:                    clock.RealClock{},
+				PermissionServiceFactory: mockFactory,
+			}
+
+			// Act
+			_, err := reconciler.Reconcile(ctx, request)
+
+			// Assert
+			Expect(err).To(HaveOccurred())
+			Eventually(func() error {
+				store := &extensionsv1.Store{}
+				err := k8sClient.Get(ctx, typeNamespacedName, store)
+				if err != nil {
+					return err
+				}
+				if store.Spec.Id != existingStoreId {
+					return fmt.Errorf("expected store id %s, got %s", existingStoreId, store.Spec.Id)
+				}
+				return nil
+			}, duration, interval).Should(Succeed())
+			Consistently(func() error {
+				authModel := &extensionsv1.AuthorizationModel{}
+				return k8sClient.Get(ctx, typeNamespacedName, authModel)
+			}, duration, interval).ShouldNot(Succeed())
+			Eventually(func() (extensionsv1.AuthorizationModelRequestStatusState, error) {
+				authModelRequest := &extensionsv1.AuthorizationModelRequest{}
+				if err := k8sClient.Get(ctx, typeNamespacedName, authModelRequest); err != nil {
+					return "", err
+				}
+				return authModelRequest.Status.State, nil
+			}, duration, interval).Should(Equal(extensionsv1.SynchronizationFailed))
+			validateEvent(fakeRecorder.Events, EventReasonAuthorizationModelCreationFailed)
+		})
+
 		It("given existing store and authorization model, then do not call open fga", func() {
 			// Arrange
 			existingStoreId := uuid.NewString()
@@ -174,11 +319,18 @@ var _ = Describe("AuthorizationModelRequest Controller", func() {
 			mockFactory := fgainternal.NewMockPermissionServiceFactory(goMockController)
 			mockService := fgainternal.NewMockPermissionService(goMockController)
 			mockFactory.EXPECT().GetService(gomock.Any()).Return(mockService, nil).Times(1)
+
 			mockService.EXPECT().CheckExistingStoresByName(gomock.Any(), gomock.Any()).Times(0)
-			mockService.EXPECT().CheckExistingStoresById(gomock.Any(), gomock.Any()).Times(1)
+			mockService.EXPECT().CheckExistingStoresById(gomock.Any(), gomock.Any()).Return(&fgainternal.Store{
+				Id:        existingStoreId,
+				Name:      resourceName,
+				CreatedAt: time.Now(),
+			}, nil).Times(1)
 			mockService.EXPECT().CreateStore(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			mockService.EXPECT().SetStoreId(gomock.Any()).Times(1)
+
 			mockService.EXPECT().CreateAuthorizationModel(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			mockService.EXPECT().CheckAuthorizationModelExists(gomock.Any(), gomock.Any()).Times(1).Return(true, nil)
 
 			reconciler := &AuthorizationModelRequestReconciler{
 				Client:                   k8sClient,

--- a/operator/internal/controller/authorizationmodelrequest/suite_test.go
+++ b/operator/internal/controller/authorizationmodelrequest/suite_test.go
@@ -126,7 +126,7 @@ func setupMockFactory() fgainternal.PermissionServiceFactory {
 	authModelId := "123"
 
 	mockFactory.EXPECT().GetService(gomock.Any()).Return(mockService, nil).AnyTimes()
-	mockService.EXPECT().CheckExistingStores(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	mockService.EXPECT().CheckExistingStoresByName(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	mockService.EXPECT().CreateStore(gomock.Any(), gomock.Any(), gomock.Any()).Return(&store, nil).AnyTimes()
 	mockService.EXPECT().SetStoreId(gomock.Any()).AnyTimes()
 	mockService.EXPECT().

--- a/operator/internal/openfga/mock_openfga_service.go
+++ b/operator/internal/openfga/mock_openfga_service.go
@@ -73,19 +73,34 @@ func (m *MockPermissionService) EXPECT() *MockPermissionServiceMockRecorder {
 	return m.recorder
 }
 
-// CheckExistingStores mocks base method.
-func (m *MockPermissionService) CheckExistingStores(ctx context.Context, storeName string) (*Store, error) {
+// CheckExistingStoresById mocks base method.
+func (m *MockPermissionService) CheckExistingStoresById(ctx context.Context, storeId string) (*Store, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckExistingStores", ctx, storeName)
+	ret := m.ctrl.Call(m, "CheckExistingStoresById", ctx, storeId)
 	ret0, _ := ret[0].(*Store)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CheckExistingStores indicates an expected call of CheckExistingStores.
-func (mr *MockPermissionServiceMockRecorder) CheckExistingStores(ctx, storeName interface{}) *gomock.Call {
+// CheckExistingStoresById indicates an expected call of CheckExistingStoresById.
+func (mr *MockPermissionServiceMockRecorder) CheckExistingStoresById(ctx, storeId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckExistingStores", reflect.TypeOf((*MockPermissionService)(nil).CheckExistingStores), ctx, storeName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckExistingStoresById", reflect.TypeOf((*MockPermissionService)(nil).CheckExistingStoresById), ctx, storeId)
+}
+
+// CheckExistingStoresByName mocks base method.
+func (m *MockPermissionService) CheckExistingStoresByName(ctx context.Context, storeName string) (*Store, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckExistingStoresByName", ctx, storeName)
+	ret0, _ := ret[0].(*Store)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckExistingStoresByName indicates an expected call of CheckExistingStoresByName.
+func (mr *MockPermissionServiceMockRecorder) CheckExistingStoresByName(ctx, storeName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckExistingStoresByName", reflect.TypeOf((*MockPermissionService)(nil).CheckExistingStoresByName), ctx, storeName)
 }
 
 // CreateAuthorizationModel mocks base method.

--- a/operator/internal/openfga/mock_openfga_service.go
+++ b/operator/internal/openfga/mock_openfga_service.go
@@ -73,6 +73,21 @@ func (m *MockPermissionService) EXPECT() *MockPermissionServiceMockRecorder {
 	return m.recorder
 }
 
+// CheckAuthorizationModelExists mocks base method.
+func (m *MockPermissionService) CheckAuthorizationModelExists(ctx context.Context, authorizationModelId string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckAuthorizationModelExists", ctx, authorizationModelId)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckAuthorizationModelExists indicates an expected call of CheckAuthorizationModelExists.
+func (mr *MockPermissionServiceMockRecorder) CheckAuthorizationModelExists(ctx, authorizationModelId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckAuthorizationModelExists", reflect.TypeOf((*MockPermissionService)(nil).CheckAuthorizationModelExists), ctx, authorizationModelId)
+}
+
 // CheckExistingStoresById mocks base method.
 func (m *MockPermissionService) CheckExistingStoresById(ctx context.Context, storeId string) (*Store, error) {
 	m.ctrl.T.Helper()

--- a/operator/internal/openfga/openfga_service.go
+++ b/operator/internal/openfga/openfga_service.go
@@ -19,7 +19,8 @@ type PermissionService interface {
 	SetStoreId(storeId string)
 	SetAuthorizationModelId(authorizationModelId string) error
 	CreateAuthorizationModel(ctx context.Context, authorizationModel string, log *logr.Logger) (string, error)
-	CheckExistingStores(ctx context.Context, storeName string) (*Store, error)
+	CheckExistingStoresByName(ctx context.Context, storeName string) (*Store, error)
+	CheckExistingStoresById(ctx context.Context, storeId string) (*Store, error)
 	CreateStore(ctx context.Context, storeName string, log *logr.Logger) (*Store, error)
 }
 
@@ -61,7 +62,15 @@ func (s *OpenFgaService) SetStoreId(storeId string) {
 	s.client.SetStoreId(storeId)
 }
 
-func (s *OpenFgaService) CheckExistingStores(ctx context.Context, storeName string) (*Store, error) {
+func (s *OpenFgaService) CheckExistingStoresByName(ctx context.Context, storeName string) (*Store, error) {
+	return s.checkExistingStores(ctx, storeName, "")
+}
+
+func (s *OpenFgaService) CheckExistingStoresById(ctx context.Context, storeId string) (*Store, error) {
+	return s.checkExistingStores(ctx, "", storeId)
+}
+
+func (s *OpenFgaService) checkExistingStores(ctx context.Context, storeName, storeId string) (*Store, error) {
 	pageSize := openfga.PtrInt32(10)
 	options := ofgaClient.ClientListStoresOptions{
 		PageSize: pageSize,
@@ -72,7 +81,7 @@ func (s *OpenFgaService) CheckExistingStores(ctx context.Context, storeName stri
 			return nil, err
 		}
 		for _, oldStore := range stores.Stores {
-			if oldStore.Name == storeName {
+			if storeName != "" && oldStore.Name == storeName || storeId != "" && oldStore.Id == storeId {
 				return &Store{
 					Id:        oldStore.Id,
 					Name:      oldStore.Name,

--- a/operator/internal/openfga/openfga_service_test.go
+++ b/operator/internal/openfga/openfga_service_test.go
@@ -47,7 +47,7 @@ func setupIntegrationTest(t *testing.T) {
 	logger = log.FromContext(context.Background())
 }
 
-func TestPositiveStoreIntegration(t *testing.T) {
+func TestPositiveCheckExistingStoresByIdIntegration(t *testing.T) {
 	// Arrange
 	setupIntegrationTest(t)
 	testStoreName := uuid.NewString()
@@ -59,7 +59,7 @@ func TestPositiveStoreIntegration(t *testing.T) {
 	}
 
 	// Assert
-	existingStore, err := service.CheckExistingStores(ctx, testStoreName)
+	existingStore, err := service.CheckExistingStoresById(ctx, createdStore.Id)
 	if err != nil {
 		t.Fatalf("failed to check existing stores: %v", err)
 	}
@@ -72,13 +72,53 @@ func TestPositiveStoreIntegration(t *testing.T) {
 	}
 }
 
-func TestNegativeStoreIntegration(t *testing.T) {
+func TestNegativeCheckExistingStoresByIdIntegration(t *testing.T) {
+	// Arrange
+	setupIntegrationTest(t)
+	nonExistingStoreId := "non-existing-store"
+
+	// Assert
+	nonExistingStore, err := service.CheckExistingStoresById(ctx, nonExistingStoreId)
+	if err != nil {
+		t.Fatalf("failed to check existing stores: %v", err)
+	}
+	if nonExistingStore != nil {
+		t.Fatalf("expected store %q to be non-existent, but it exists", nonExistingStoreId)
+	}
+}
+
+func TestPositiveCheckExistingStoresByNameIntegration(t *testing.T) {
+	// Arrange
+	setupIntegrationTest(t)
+	testStoreName := uuid.NewString()
+
+	// Act
+	createdStore, err := service.CreateStore(ctx, testStoreName, &logger)
+	if err != nil {
+		t.Fatalf("failed to create test store: %v", err)
+	}
+
+	// Assert
+	existingStore, err := service.CheckExistingStoresByName(ctx, testStoreName)
+	if err != nil {
+		t.Fatalf("failed to check existing stores: %v", err)
+	}
+
+	if existingStore == nil {
+		t.Fatalf("expected test store %q to exist, but it doesn't", testStoreName)
+	}
+	if existingStore.Name != createdStore.Name || existingStore.Id != createdStore.Id {
+		t.Fatalf("created store %q does not match the store returned by CheckExistingStores", testStoreName)
+	}
+}
+
+func TestNegativeCheckExistingStoresByNameIntegration(t *testing.T) {
 	// Arrange
 	setupIntegrationTest(t)
 	nonExistingStoreName := "non-existing-store"
 
 	// Assert
-	nonExistingStore, err := service.CheckExistingStores(ctx, nonExistingStoreName)
+	nonExistingStore, err := service.CheckExistingStoresByName(ctx, nonExistingStoreName)
 	if err != nil {
 		t.Fatalf("failed to check existing stores: %v", err)
 	}

--- a/operator/internal/openfga/openfga_service_test.go
+++ b/operator/internal/openfga/openfga_service_test.go
@@ -127,6 +127,54 @@ func TestNegativeCheckExistingStoresByNameIntegration(t *testing.T) {
 	}
 }
 
+func TestPositiveCheckAuthorizationModelExistsIntegration(t *testing.T) {
+	// Arrange
+	setupIntegrationTest(t)
+	storeName := uuid.NewString()
+	store, err := service.CreateStore(ctx, storeName, &logger)
+	if err != nil {
+		t.Fatalf("failed to seed store: %v", err)
+	}
+	service.SetStoreId(store.Id)
+	modelId, err := service.CreateAuthorizationModel(ctx, model, &logger)
+	if err != nil {
+		t.Fatalf("failed to create authorization model: %v", err)
+	}
+
+	// Act
+	modelExists, err := service.CheckAuthorizationModelExists(ctx, modelId)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("failed to check existing models: %v", err)
+	}
+	if !modelExists {
+		t.Fatalf("expected model to exists")
+	}
+}
+
+func TestNegativeCheckAuthorizationModelExistsIntegration(t *testing.T) {
+	// Arrange
+	setupIntegrationTest(t)
+	storeName := uuid.NewString()
+	store, err := service.CreateStore(ctx, storeName, &logger)
+	if err != nil {
+		t.Fatalf("failed to seed store: %v", err)
+	}
+	service.SetStoreId(store.Id)
+
+	// Act
+	modelExists, err := service.CheckAuthorizationModelExists(ctx, uuid.NewString())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("failed to check existing models: %v", err)
+	}
+	if modelExists {
+		t.Fatalf("didn't expect model to exists")
+	}
+}
+
 func TestCreateAuthorizationModelIntegration(t *testing.T) {
 	setupIntegrationTest(t)
 


### PR DESCRIPTION
Introduced `existingStoreId` and `existingAuthorizationModelId ` such that one can migrate to the operator and keep current used store and authorization model.

`AuthorizationModelRequest` would then look like below

```
apiVersion: extensions.fga-operator/v1
kind: AuthorizationModelRequest
metadata:
  name: documents
spec:
  existingStoreId: 01J1N8HCY7MQP4QP3GVDWTM9ZG
  instances:
    - version:
        major: 1
        minor: 1
        patch: 1
      existingAuthorizationModelId: 01J23CJTA8X4K87X62ECX1Y58Z
      authorizationModel: |
        model
          schema 1.1
          
        type user
          
        type document
          relations
            define reader: [user]
            define writer: [user]
            define owner: [user]
```